### PR TITLE
Improved corner cases for appimage icon detection

### DIFF
--- a/usr/bin/xapp-appimage-thumbnailer
+++ b/usr/bin/xapp-appimage-thumbnailer
@@ -22,11 +22,21 @@ f.close()
 
 # Find the location of the icon inside the squashfs
 icon_path = None
-output = subprocess.getoutput(f"unsquashfs -o {app_image_offset} -ll '{t.args.input}' | grep .DirIcon")
-for line in output.split("\n"):
-    if "-> " in line:
-        icon_path = line.strip().split("-> ")[1]
-        break
+status, output = subprocess.getstatusoutput(f"unsquashfs -o {app_image_offset} -ll '{t.args.input}' | grep '.DirIcon -> '")
+
+# Case where .DirIcon is an image or is missing
+if status != 0:
+    status, output = subprocess.getstatusoutput(f"unsquashfs -o {app_image_offset} -ll '{t.args.input}' | grep .DirIcon")
+    icon_path = ".DirIcon" if status == 0 else None
+
+# Case where .DirIcon is a symlink or symlink chain
+else:
+    while "-> " in output:
+        icon_path = output.strip().split("-> ")[1]
+        # Some appimages use local apppimage paths, e.g., ./usr/applications/...
+        if icon_path[0:2] == "./":
+            icon_path = icon_path[2:]
+        output = subprocess.getoutput(f"unsquashfs -o {app_image_offset} -ll '{t.args.input}' | grep '{icon_path} -> '")
 
 # Extract the icon
 if icon_path != None:


### PR DESCRIPTION
Hi!

I've detected some corner cases that are not handled by the current implementation of the `AppImage` thumbnailer. Here are the possibilities I've found out for `.DirIcon`, where the checkmark indicates the current support:
- [x] Is a symlink to a image file
- [ ] Is a symlink chain to an image file
- [ ] Is an image file

I've found some apps in `appimagepool`, that exemplify this issue:
- Apps where .DirIcon is not symlink
  - textosaurus
  - procyon
  - Qrop
- Apps where .DirIcon points to another symlink
  - Appimagepool
  - popsicle
  - OpenTodoList

The change in this PR covers the missing cases.
