### PR TITLE
feat: add thumbnailer for audio files with VorbisComment metadata (FLAC & Ogg)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,6 +30,13 @@ Depends: xapp-thumbnailers-common, dcraw
 Description: RAW thumbnailer
  Produces thumbnails for RAW files.
 
+Package: xapp-vorbiscomment-thumbnailer
+Architecture: all
+Depends: xapp-thumbnailers-common, python3-mutagen
+Description: VorbisComment thumbnailer
+ Produces thumbnails for audio files with VorbisComment metadata,
+ such as FLAC and Ogg files.
+
 Package: xapp-appimage-thumbnailer
 Architecture: all
 Depends: xapp-thumbnailers-common, python3-pyelftools, squashfs-tools

--- a/debian/xapp-vorbiscomment-thumbnailer.install
+++ b/debian/xapp-vorbiscomment-thumbnailer.install
@@ -1,0 +1,2 @@
+usr/bin/xapp-vorbiscomment-thumbnailer
+usr/share/thumbnailers/xapp-vorbiscomment-thumbnailer.thumbnailer

--- a/usr/bin/xapp-vorbiscomment-thumbnailer
+++ b/usr/bin/xapp-vorbiscomment-thumbnailer
@@ -1,0 +1,34 @@
+#!/usr/bin/python3
+"""Extracts the album cover of FLAC and OGG files using the mutagen library.
+Other supported formats could be added in future.
+
+Ref: https://mutagen.readthedocs.io/en/latest/user/vcomment.html
+"""
+import base64
+import mutagen
+from mutagen.flac import FLAC, Picture
+from mutagen.ogg import OggFileType
+import sys
+
+from XappThumbnailers import Thumbnailer
+
+thumbnailer = Thumbnailer()
+
+try:
+    filename = thumbnailer.args.input
+    file = mutagen.File(filename=filename)
+    cover_bytes: bytes
+
+    if isinstance(file, FLAC):
+        cover_bytes = file.pictures[0].data
+    elif isinstance(file, OggFileType):
+        cover_b64 = file.get('metadata_block_picture', [None])[0]
+        if not cover_b64:
+            cover_b64 = file.get('coverart', [None])[0]  # check legacy attrib
+        cover_bytes = Picture(base64.b64decode(cover_b64)).data
+    else:
+        sys.exit(1)
+
+    thumbnailer.save_bytes(cover_bytes)
+except Exception:
+    sys.exit(1)

--- a/usr/share/thumbnailers/xapp-vorbiscomment-thumbnailer.thumbnailer
+++ b/usr/share/thumbnailers/xapp-vorbiscomment-thumbnailer.thumbnailer
@@ -1,0 +1,4 @@
+[Thumbnailer Entry]
+TryExec=xapp-vorbiscomment-thumbnailer
+Exec=xapp-vorbiscomment-thumbnailer -i %i -o %o -s %s
+MimeType=audio/flac;audio/ogg;x-flac+ogg.xml;audio/x-opus+ogg;x-speex+ogg.xml;audio/x-vorbis+ogg


### PR DESCRIPTION
This adds album cover thumbnails for FLAC and Ogg audio files.
The code uses the mutagen python library, which also supports other audio formats such as MP3, so that we could also expand this thumbnailer to replace the existing mp3 thumbnailer.

Fixes: #4 