### PR TITLE
Execute external commands without involving the shell

### DIFF
--- a/files/usr/bin/xapp-appimage-thumbnailer
+++ b/files/usr/bin/xapp-appimage-thumbnailer
@@ -1,52 +1,57 @@
 #!/usr/bin/python3
 
 import os
-import random
 import subprocess
 import sys
+import tempfile
 from elftools.elf.elffile import ELFFile
 
 import XappThumbnailers
 t = XappThumbnailers.Thumbnailer()
 
-rand_int = random.randint(0, 1000)
-TMP_DIR = f"/tmp/appimage{rand_int}.thumbnail"
-os.system(f"mkdir -p '{TMP_DIR}'")
-os.system(f"rm -rf '{TMP_DIR}'/*")
-os.chdir(TMP_DIR)
-
 # Find the section header offset within the ELF file
-f = open(t.args.input, 'rb')
-elf = ELFFile(f)
-app_image_offset = elf['e_shoff'] + (elf['e_shentsize'] * elf['e_shnum'])
-f.close()
+with open(t.args.input, 'rb') as f:
+    elf = ELFFile(f)
+    app_image_offset = elf['e_shoff'] + (elf['e_shentsize'] * elf['e_shnum'])
+
+def squashfs_lookup(filename):
+    return subprocess.check_output([
+            'unsquashfs',
+            '-o', str(app_image_offset),
+            '-ll',
+            t.args.input,
+            filename
+        ]).decode()
 
 # Find the location of the icon inside the squashfs
-icon_path = None
-status, output = subprocess.getstatusoutput(f"unsquashfs -o {app_image_offset} -ll '{t.args.input}' | grep '.DirIcon -> '")
+icon_path = '.DirIcon'
+while True:
+    output = squashfs_lookup(icon_path)
 
-# Case where .DirIcon is an image or is missing
-if status != 0:
-    status, output = subprocess.getstatusoutput(f"unsquashfs -o {app_image_offset} -ll '{t.args.input}' | grep .DirIcon")
-    icon_path = ".DirIcon" if status == 0 else None
+    if not output:
+        # File not found, fail
+        sys.exit(1)
 
-# Case where .DirIcon is a symlink or symlink chain
-else:
-    while "-> " in output:
-        icon_path = output.strip().split("-> ")[1]
-        # Some appimages use local apppimage paths, e.g., ./usr/applications/...
-        if icon_path[0:2] == "./":
-            icon_path = icon_path[2:]
-        output = subprocess.getoutput(f"unsquashfs -o {app_image_offset} -ll '{t.args.input}' | grep '{icon_path} -> '")
+    if ' -> ' not in output:
+        # icon path is not a symlink, let's use it
+        break
+
+    icon_path = output.strip().split(' -> ')[1]
+    # Some appimages use local apppimage paths, e.g., ./usr/applications/...
+    if icon_path[0:2] == './':
+        icon_path = icon_path[2:]
 
 # Extract the icon
-if icon_path != None:
-    subprocess.getoutput(f"echo '{icon_path}' > files")
-    cmd = f"unsquashfs -o {app_image_offset} -e files '{t.args.input}'"
-    output = subprocess.getoutput(cmd)
-    icon_path = os.path.join(TMP_DIR, "squashfs-root", icon_path)
+with tempfile.TemporaryDirectory() as tmpdir:
+    outdir = os.path.join(tmpdir, 'out')
+    cmd = [
+            'unsquashfs',
+            '-o', str(app_image_offset),
+            '-d', outdir,
+            t.args.input,
+            icon_path,
+        ]
+    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    icon_path = os.path.join(outdir, icon_path)
     success = t.save_path(icon_path)
-    os.system(f"rm -rf '{TMP_DIR}'")
-    sys.exit(0 if success else 1)
-
-sys.exit(1)
+sys.exit(0 if success else 1)

--- a/files/usr/bin/xapp-raw-thumbnailer
+++ b/files/usr/bin/xapp-raw-thumbnailer
@@ -6,15 +6,14 @@ import sys
 
 import XappThumbnailers
 t = XappThumbnailers.Thumbnailer()
-tmp_path = t.args.output + ".tmp.jpg"
 
 try:
-    cproc = subprocess.run(f"dcraw -c -e -w '{t.args.input}' > '{tmp_path}'", check=True, shell=True)
+    output = subprocess.check_output([
+            'dcraw', '-c', '-e', '-w', t.args.input,
+        ])
 except subprocess.CalledProcessError as e:
     print(e)
     sys.exit(1)
 
-success = t.save_path(tmp_path)
-os.unlink(tmp_path)
-
-sys.exit(0 if success else 1)
+t.save_bytes(output)
+sys.exit(0)


### PR DESCRIPTION
`xapp-appimage-thumbnailer` and `xapp-raw-thumbnailer` will call the following functions with untrusted filenames, which makes them vulnerable to command injection.

`subprocess.run(..., shell=True)`
`subprocess.getoutput(...)`
`os.system(...)`

Here is a PoC script that triggers the vulnerability in `xapp-appimage-thumbnailer`

```
#!/usr/bin/env python3

import tempfile
import os
import shutil
import subprocess
import random

filename = f'''
'$(zenity --info --text="You have been pwned!")'{random.randrange(2**32)}.appimage
'''.strip()

with tempfile.TemporaryDirectory() as dirname:
    path = os.path.join(dirname, filename)
    # Copy an arbitrary ELF
    shutil.copyfile('/bin/sh', path)
    # Open nemo to trigger the thumbnailer
    # This takes a few seconds
    subprocess.call(['nemo', dirname])
```

A realistic attack vector would not be a script, but rather an email attachment / USB stick / ZIP archive / etc.

This PR still runs external commands `unsquashfs`/`dcraw` as before, but now without involving the shell.
