### PR TITLE
Add Panasonic RW2 raw files support

### DIFF
--- a/files/usr/share/thumbnailers/xapp-raw-thumbnailer.thumbnailer
+++ b/files/usr/share/thumbnailers/xapp-raw-thumbnailer.thumbnailer
@@ -1,4 +1,4 @@
 [Thumbnailer Entry]
 TryExec=xapp-raw-thumbnailer
 Exec=xapp-raw-thumbnailer -i %i -o %o -s %s
-MimeType=image/x-sony-arw;image/x-canon-cr2;image/x-canon-crw;image/x-kodak-dcr;image/x-adobe-dng;image/x-epson-erf;image/x-kodak-k25;image/x-kodak-kdc;image/x-minolta-mrw;image/x-nikon-nef;image/x-olympus-orf;image/x-pentax-pef;image/x-fuji-raf;image/x-panasonic-raw;image/x-sony-sr2;image/x-sony-srf;image/x-sigma-x3f;
+MimeType=image/x-sony-arw;image/x-canon-cr2;image/x-canon-crw;image/x-kodak-dcr;image/x-adobe-dng;image/x-epson-erf;image/x-kodak-k25;image/x-kodak-kdc;image/x-minolta-mrw;image/x-nikon-nef;image/x-olympus-orf;image/x-pentax-pef;image/x-fuji-raf;image/x-panasonic-raw;image/x-panasonic-rw2;image/x-sony-sr2;image/x-sony-srf;image/x-sigma-x3f;


### PR DESCRIPTION
Some Panasonic camera produces RW2 raw files (with image/x-panasonic-rw2 as mime type). This format is also supported by dcraw.

This PR is to add the RW2 mime type to xapp-raw-thumbnailer.thumbnailer, to allows creating thumbnails for Panasonic RW2 files.