### PR TITLE
Fix bug in aiff extractor

### DIFF
--- a/files/usr/bin/xapp-aiff-thumbnailer
+++ b/files/usr/bin/xapp-aiff-thumbnailer
@@ -18,8 +18,6 @@ def extract_cover_aiff_file(filepath: Path) -> bytes | None:
     try:
         return cast(bytes, aiff_file.tags.getall("APIC")[0].data)
     except:
-        pass
-    finally:
         return None
 
 


### PR DESCRIPTION
Fix a bug in the extractor, it was always returning `None` instead of the bytes of the cover.

With the changes works as expected:

![image](https://github.com/user-attachments/assets/0a544f82-65a2-4805-ab86-5cd77c4344cf)
