### PR TITLE
Updating MimeType and deleting checking the extension in the aiff thumbnailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ All file managers which are compatible with `/usr/share/thumbnailers` thumbnaile
 - [Nautilus (GNOME)](https://gitlab.gnome.org/GNOME/nautilus)
 - [Nemo (Cinnamon)](https://github.com/linuxmint/nemo)
 - [PCManFM (LXDE)](https://github.com/lxde/pcmanfm)
+- [PCManFM-Qt (LXQt)](https://github.com/lxqt/pcmanfm-qt)
 - [Thunar (Xfce)](https://gitlab.xfce.org/xfce/thunar)
 
 So far the following file types are supported:
@@ -19,3 +20,4 @@ So far the following file types are supported:
 - **ePub** (compressed as ZIP, with a cover specified as a `cover-image` property, or a `cover` meta tag).
 - **MP3** (with album art specified in their ID3 images tag)
 - **RAW** (compatible with dcraw)
+- **aiff** (for audio files with cover art embedded in their tags)

--- a/files/usr/bin/xapp-aiff-thumbnailer
+++ b/files/usr/bin/xapp-aiff-thumbnailer
@@ -11,8 +11,6 @@ thumbnailer = Thumbnailer()
 
 def extract_cover_aiff_file(filepath: Path) -> bytes | None:
     try:
-        if not filepath.is_file() or not filepath.suffix.lower() == ".aiff":
-            return None
         aiff_file: AIFF = AIFF(str(filepath))
         if aiff_file.tags is None:
             return None

--- a/files/usr/bin/xapp-aiff-thumbnailer
+++ b/files/usr/bin/xapp-aiff-thumbnailer
@@ -14,7 +14,7 @@ def extract_cover_aiff_file(filepath: Path) -> bytes | None:
         aiff_file: AIFF = AIFF(str(filepath))
         if aiff_file.tags is None:
             return None
-        return cast(bytes, aiff_file.tags.getall("APIC")[0].data)
+        return cast(bytes, aiff_file.tags.getall(key="APIC")[0].data)
     except:
         return None
 

--- a/files/usr/share/thumbnailers/xapp-aiff-thumbnailer.thumbnailer
+++ b/files/usr/share/thumbnailers/xapp-aiff-thumbnailer.thumbnailer
@@ -1,4 +1,4 @@
 [Thumbnailer Entry]
 TryExec=xapp-aiff-thumbnailer
 Exec=xapp-aiff-thumbnailer -i %i -o %o -s %s
-MimeType=audio/x-aiff
+MimeType=audio/x-aiff;audio/aiff


### PR DESCRIPTION
Based on the information about the `.aiff` format provided in [https://en.wikipedia.org/wiki/Audio_Interchange_File_Format](https://en.wikipedia.org/wiki/Audio_Interchange_File_Format), this PR is to update the MimeType of the thumbnailer and also deleting a section in the code that it was checking the file extension (it wasn't necessary since the `.thumbnailer` file is doing that job already in the MimeType attribute)