### PR TITLE
Fix JXL thumbnailer failing on files incompatible with forced 16-bit output

### DIFF
--- a/files/usr/bin/xapp-jxl-thumbnailer
+++ b/files/usr/bin/xapp-jxl-thumbnailer
@@ -14,7 +14,7 @@ t = XappThumbnailers.Thumbnailer()
 try:
     with tempfile.NamedTemporaryFile(dir=XApp.get_tmp_dir(), suffix=".png") as tempf:
         output = subprocess.check_output([
-            "djxl", "--bits_per_sample", "16", "--num_threads", "1", "--quiet", t.args.input, tempf.name
+            "djxl", "--num_threads", "1", "--quiet", t.args.input, tempf.name
         ])
 
         pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale(tempf.name, t.args.size, t.args.size, True)


### PR DESCRIPTION
This patch fixes a decoding failure in the JXL thumbnailer caused by the
hard‑coded `--bits_per_sample 16` argument passed to `djxl`.

Some valid JPEG XL files cannot be decoded into 16‑bit PNG output. When the
thumbnailer forces 16‑bit output, `djxl` exits with:

    JXL_FAILURE: Bit depth does not fit pixel data type
    JXL_RETURN_IF_ERROR code=1: VerifyPackedImage(frame.color, ppf.info)
    Encode failed

As a result, Nemo silently fails to generate thumbnails for these files.

According to the [freedesktop.org thumbnail specification](https://specifications.freedesktop.org/thumbnail/latest/creation.html#id-1.6.2), thumbnails must be
stored as 8‑bit, non‑interlaced PNG images. Forcing 16‑bit output provides no
benefit for thumbnail generation and reduces compatibility.

This change removes the `--bits_per_sample 16` argument so that `djxl` can
choose an appropriate output format automatically. Thumbnail generation
works reliably for all tested JXL files after this change.

No other behavior is affected.

Closes #21 